### PR TITLE
Restrict package to Win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are several configuration settings supported:
 | `certificateFile`     | No       | The path to an Authenticode Code Signing Certificate |
 | `certificatePassword` | No       | The password to decrypt the certificate given in `certificateFile` |
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
+| `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
 | `remoteReleases`      | No       | A URL to your existing updates. If given, these will be downloaded to create delta updates |
 
@@ -73,7 +74,7 @@ and uninstalls. it is **very** important that your app handle these events as _e
 as possible, and quit **immediately** after handling them. Squirrel will give your
 app a short amount of time (~15sec) to apply these operations and quit.
 
-You should handle these events in your app's `main` entry point with something 
+You should handle these events in your app's `main` entry point with something
 such as:
 
 ```js
@@ -109,7 +110,7 @@ var handleStartupEvent = function() {
 
       return true;
     case '--squirrel-obsolete':
-      // This is called on the outgoing version of your app before 
+      // This is called on the outgoing version of your app before
       // we update to the new version - it's the opposite of
       // --squirrel-updated
       app.quit();

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Grunt plugin that builds Windows installers for
 
 ## Installing
 
+**Note:**
+Currently grunt-electron-installer only works on **Windows only**.
+
 ```sh
 npm install --save-dev grunt-electron-installer
 ```
+
+If you want to include this plugin in a cross platform project, install it with `--save-optional` instead of `--save-dev`.
+This will prevent installation error on Mac/Linux.
 
 ## Configuring
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prepublish": "grunt clean lint coffee",
     "test": "grunt test"
   },
+  "os": [
+    "win32"
+  ],
   "dependencies": {
     "temp": "^0.8.1",
     "underscore": "^1.7.0",


### PR DESCRIPTION
It was pretty confusing trying to run builds on Linux (as the errors that arise are pretty vague, see #22), so I suggest restricting installs outright on other OS' and suggesting devs use `optionalDependencies` in their package.