### PR TITLE
Change to Multi-build grunt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,24 @@ you can configure the installer task like so:
 
 ```js
 'create-windows-installer': {
-  appDirectory: '/tmp/build/my-app',
-  outputDirectory: '/tmp/build/installer',
-  authors: 'My App Inc.',
-  exe: 'myapp.exe'
+  x64: {
+    appDirectory: '/tmp/build/my-app-64',
+    outputDirectory: '/tmp/build/installer64',
+    authors: 'My App Inc.',
+    exe: 'myapp.exe'
+  },
+  ia32: {
+    appDirectory: '/tmp/build/my-app-32',
+    outputDirectory: '/tmp/build/installer32',
+    authors: 'My App Inc.',
+    exe: 'myapp.exe'
+  }
 }
 ```
 
 Then run `grunt create-windows-installer` and you will have an `.nupkg`, a
-`RELEASES` file, and a `.exe` installer file in the `outputDirectory` folder.
+`RELEASES` file, and a `.exe` installer file in the `outputDirectory` folder
+for each multi task target given under the config entry.
 
 There are several configuration settings supported:
 

--- a/index.coffee
+++ b/index.coffee
@@ -13,12 +13,12 @@ module.exports = (grunt) ->
       grunt.log.error(stderr) if stderr
       callback(error)
 
-  grunt.registerTask 'create-windows-installer', 'Create the Windows installer', ->
-    @requiresConfig("#{@name}.appDirectory")
+  grunt.registerMultiTask 'create-windows-installer', 'Create the Windows installer', ->
+    @requiresConfig("#{@name}.#{@target}.appDirectory")
 
     done = @async()
 
-    config = grunt.config(@name)
+    config = grunt.config("#{@name}.#{@target}")
 
     appDirectory = path.resolve(config.appDirectory)
 


### PR DESCRIPTION
Instead of allowing both single and multi target, this was a bit more straightforward to simply use standard multi config as most grunt plugins usually do. Also the common use case would be to have a build config for the two standard windows archs, makes sense.

A clear reason to deny this PR might be backwards compatibility with old configs, but the change is pretty simple. 