### PR TITLE
Fix obsolete setupIcon flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are several configuration settings supported:
 | `certificatePassword` | No       | The password to decrypt the certificate given in `certificateFile` |
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
 | `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
-| `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
+| `icon`                | No       | The ICO file to use as the icon for the generated Setup.exe |
 | `remoteReleases`      | No       | A URL to your existing updates. If given, these will be downloaded to create delta updates |
 
 ## Sign your installer or else bad things will happen

--- a/index.coffee
+++ b/index.coffee
@@ -102,10 +102,10 @@ module.exports = (grunt) ->
           args.push '--signWithParams'
           args.push "/a /f \"#{path.resolve(certificateFile)}\" /p \"#{certificatePassword}\""
 
-        if config.setupIcon
-          setupIconPath = path.resolve(config.setupIcon)
-          args.push '--setupIcon'
-          args.push setupIconPath
+        if config.icon or config.setupIcon
+          iconPath = path.resolve(config.icon or config.setupIcon)
+          args.push '--icon'
+          args.push iconPath
 
         exec {cmd, args}, (error) ->
           return done(error) if error?


### PR DESCRIPTION
Must be merged ASAP due to
https://github.com/Squirrel/Squirrel.Windows/pull/427/files#diff-2e8940665a1334ba611551359297280eL120

This merge keeps setupIcon flag for backward compatibility.