### PR TITLE
setupIcon -> icon

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -102,10 +102,10 @@ module.exports = (grunt) ->
           args.push '--signWithParams'
           args.push "/a /f \"#{path.resolve(certificateFile)}\" /p \"#{certificatePassword}\""
 
-        if config.setupIcon
-          setupIconPath = path.resolve(config.setupIcon)
-          args.push '--setupIcon'
-          args.push setupIconPath
+        if config.icon
+          iconPath = path.resolve(config.icon)
+          args.push '--icon'
+          args.push iconPath
 
         exec {cmd, args}, (error) ->
           return done(error) if error?


### PR DESCRIPTION
Updates the icon parameter to match recent changes in Squirrel Windows. This fixes the icon on the SetupApp.exe.

We are having problems getting `Update.exe --createShortcut` to work and I'm wondering if this is related to these recent icon parameter changes - there may be something else missed somewhere? 

