### PR TITLE
Allow prerelease versions

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -48,7 +48,6 @@ module.exports = (grunt) ->
     metadata.iconUrl ?= 'https://raw.githubusercontent.com/atom/electron/master/atom/browser/resources/win/atom.ico'
     metadata.owners ?= metadata.authors
     metadata.title ?= metadata.productName ? metadata.name
-    metadata.version = metadata.version.replace(/-.*$/, '')
     metadata.copyright ?= "Copyright © #{new Date().getFullYear()} #{metadata.authors ? metadata.owners}"
 
     template = _.template(grunt.file.read(path.resolve(__dirname, '..', 'template.nuspec')))

--- a/index.coffee
+++ b/index.coffee
@@ -50,10 +50,9 @@ module.exports = (grunt) ->
     metadata.title ?= metadata.productName ? metadata.name
 
     # NuGet allows pre-release version-numbers, but the pre-release name cannot
-    # have a dot in it. See:
+    # have a dot in it. See the docs:
     # https://docs.nuget.org/create/versioning#user-content-prerelease-versions
-    [versionPrefix, versionSuffix] = metadata.version.split('-')
-    metadata.version = [versionPrefix, versionSuffix.replace('.', '')].join('-')
+    metadata.version = metadata.version.replace(/\.(\d+)$/, '$1')
 
     metadata.copyright ?= "Copyright © #{new Date().getFullYear()} #{metadata.authors ? metadata.owners}"
 

--- a/index.coffee
+++ b/index.coffee
@@ -48,6 +48,13 @@ module.exports = (grunt) ->
     metadata.iconUrl ?= 'https://raw.githubusercontent.com/atom/electron/master/atom/browser/resources/win/atom.ico'
     metadata.owners ?= metadata.authors
     metadata.title ?= metadata.productName ? metadata.name
+
+    # NuGet allows pre-release version-numbers, but the pre-release name cannot
+    # have a dot in it. See:
+    # https://docs.nuget.org/create/versioning#user-content-prerelease-versions
+    [versionPrefix, versionSuffix] = metadata.version.split('-')
+    metadata.version = [versionPrefix, versionSuffix.replace('.', '')].join('-')
+
     metadata.copyright ?= "Copyright © #{new Date().getFullYear()} #{metadata.authors ? metadata.owners}"
 
     template = _.template(grunt.file.read(path.resolve(__dirname, '..', 'template.nuspec')))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-electron-installer",
-  "version": "1.0.3-0",
+  "version": "1.0.3-1",
   "description": "Grunt task to generate Windows installers for Electron apps",
   "main": "./tasks/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-electron-installer",
-  "version": "1.0.3-1",
+  "version": "1.0.3-2",
   "description": "Grunt task to generate Windows installers for Electron apps",
   "main": "./tasks/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-electron-installer",
-  "version": "1.0.3-2",
+  "version": "1.0.3-3",
   "description": "Grunt task to generate Windows installers for Electron apps",
   "main": "./tasks/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-electron-installer",
-  "version": "1.0.2",
+  "version": "1.0.3-0",
   "description": "Grunt task to generate Windows installers for Electron apps",
   "main": "./tasks/index.js",
   "license": "MIT",


### PR DESCRIPTION
NuGet packages can have prerelease versions, but the prerelease name just can't contain a dot. So for beta releases, we need to convert npm's preferred style, `1.2.0-beta.0` with `1.2.0-beta0`.