### PR TITLE
Add noMsi configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There are several configuration settings supported:
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
 | `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
+| `noMsi`               | No       | Should Squirrel.Windows create an MSI installer? |
 | `remoteReleases`      | No       | A URL to your existing updates. If given, these will be downloaded to create delta updates |
 
 ## Sign your installer or else bad things will happen

--- a/index.coffee
+++ b/index.coffee
@@ -136,6 +136,9 @@ module.exports = (grunt) ->
           setupIconPath = path.resolve(config.setupIcon)
           args.push '--setupIcon'
           args.push setupIconPath
+          
+        if config.noMsi
+          args.push '--no-msi'
 
         exec {cmd, args}, (error) ->
           return done(error) if error?


### PR DESCRIPTION
In issue #79 @lipsis requested an option to no generate an msi installer as update.exe has support for --no-msi. I added that option to grunt-electron-installer.